### PR TITLE
new meetup form formatting

### DIFF
--- a/app/views/meetups/new.html.erb
+++ b/app/views/meetups/new.html.erb
@@ -1,11 +1,17 @@
 <div class="container">
   <h1>New Meetup</div>
   <div class="row">
-    <div class="col-md-8">
-      <%= simple_form_for @meetup do | f | %>
-        <%= f.input :date %>
-        <%= f.submit "Save", class: "btn btn-primary" %>
-      <% end %>
+    <div class="col-md-12">
+      <div style="padding:20px;">
+        <%= simple_form_for @meetup do | f | %>
+          <div class="row">
+            <div class="col-md-4">
+              <%= f.input :date %>
+            </div>
+          </div>
+          <%= f.submit "Save", class: "btn btn-primary" %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixed the date selector for new meetup form so it's not butting up agains the edge of the page. Shrunk the width of the dropdowns by putting them in their own row and col width divs.
Signed-off-by: sleepydeveloper <sleepydeveloper@gmail.com>