### PR TITLE
Use non_japanese_attendees to get counts

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -13,7 +13,7 @@ class ReportsController < ApplicationController
             pointStrokeColor: "#fff",
             pointHighlightFill: "#fff",
             pointHighlightStroke: "rgba(220,220,220,1)",
-            data: @meetups.map{ | m | m.japanese_attendees.count }
+            data: @meetups.map{ |m| m.japanese_attendees.count }
         },
         {
             label: "English",
@@ -23,7 +23,7 @@ class ReportsController < ApplicationController
             pointStrokeColor: "#fff",
             pointHighlightFill: "#fff",
             pointHighlightStroke: "rgba(151,187,205,1)",
-            data: @meetups.map{ | m |m.english_attendees.count }
+            data: @meetups.map{ |m| m.non_japanese_attendees.count }
         }
     ]
 }

--- a/app/models/meetup.rb
+++ b/app/models/meetup.rb
@@ -17,6 +17,10 @@ class Meetup < ActiveRecord::Base
   #   where(native_language: language)
   # }
 
+  def non_japanese_attendees
+    attendees.where.not(native_language: 'Japanese')
+  end
+
   def english_attendees
     lookup native_language: "English"
   end

--- a/app/views/meetups/show.html.erb
+++ b/app/views/meetups/show.html.erb
@@ -7,7 +7,7 @@
       <% if @meetup.attendees.count > 0 %>
         <% data = [
             { value: @meetup.japanese_attendees.count, color:"#F7464A", highlight: "#FF5A5E", label: "Japanese"},
-            { value: @meetup.english_attendees.count, color:"#46BFBD", highlight: "#5AD3D1", label: "English"}
+            { value: @meetup.non_japanese_attendees.count, color:"#46BFBD", highlight: "#5AD3D1", label: "English"}
             ] %>
         <%= pie_chart(data,
           animation: false,


### PR DESCRIPTION
Use #non_japanese_attendees to get the counts for non native Japanese speakers.

Signed-off-by: sleepydeveloper <sleepydeveloper@gmail.com>